### PR TITLE
Renamed get().asCursor() -> get().cursor() and get().asListOfObjects() -...

### DIFF
--- a/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/get/PreparedGet.java
+++ b/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/get/PreparedGet.java
@@ -24,12 +24,12 @@ public abstract class PreparedGet<T> implements PreparedOperation<T> {
             this.bambooStorage = bambooStorage;
         }
 
-        @NonNull public PreparedGetAsCursor.Builder asCursor() {
-            return new PreparedGetAsCursor.Builder(bambooStorage);
+        @NonNull public PreparedGetCursor.Builder cursor() {
+            return new PreparedGetCursor.Builder(bambooStorage);
         }
 
-        @NonNull public <T> PreparedGetAsListOfObjects.Builder<T> asListOfObjects(@NonNull Class<T> type) {
-            return new PreparedGetAsListOfObjects.Builder<>(bambooStorage, type);
+        @NonNull public <T> PreparedGetListOfObjects.Builder<T> listOfObjects(@NonNull Class<T> type) {
+            return new PreparedGetListOfObjects.Builder<>(bambooStorage, type);
         }
     }
 

--- a/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/get/PreparedGetCursor.java
+++ b/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/get/PreparedGetCursor.java
@@ -10,9 +10,9 @@ import com.pushtorefresh.android.bamboostorage.query.Query;
 import rx.Observable;
 import rx.Subscriber;
 
-public class PreparedGetAsCursor extends PreparedGet<Cursor> {
+public class PreparedGetCursor extends PreparedGet<Cursor> {
 
-    public PreparedGetAsCursor(@NonNull BambooStorage bambooStorage, @NonNull Query query) {
+    public PreparedGetCursor(@NonNull BambooStorage bambooStorage, @NonNull Query query) {
         super(bambooStorage, query);
     }
 
@@ -47,7 +47,7 @@ public class PreparedGetAsCursor extends PreparedGet<Cursor> {
         }
 
         @NonNull public PreparedOperation<Cursor> prepare() {
-            return new PreparedGetAsCursor(bambooStorage, query);
+            return new PreparedGetCursor(bambooStorage, query);
         }
     }
 }

--- a/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/get/PreparedGetListOfObjects.java
+++ b/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/get/PreparedGetListOfObjects.java
@@ -14,11 +14,11 @@ import java.util.List;
 import rx.Observable;
 import rx.Subscriber;
 
-public class PreparedGetAsListOfObjects<T> extends PreparedGet<List<T>> {
+public class PreparedGetListOfObjects<T> extends PreparedGet<List<T>> {
 
     @NonNull private final MapFunc<Cursor, T> mapFunc;
 
-    PreparedGetAsListOfObjects(@NonNull BambooStorage bambooStorage, @NonNull Query query, @NonNull MapFunc<Cursor, T> mapFunc) {
+    PreparedGetListOfObjects(@NonNull BambooStorage bambooStorage, @NonNull Query query, @NonNull MapFunc<Cursor, T> mapFunc) {
         super(bambooStorage, query);
         this.mapFunc = mapFunc;
     }
@@ -75,7 +75,7 @@ public class PreparedGetAsListOfObjects<T> extends PreparedGet<List<T>> {
         }
 
         @NonNull public PreparedOperation<List<T>> prepare() {
-            return new PreparedGetAsListOfObjects<>(bambooStorage, query, mapFunc);
+            return new PreparedGetListOfObjects<>(bambooStorage, query, mapFunc);
         }
     }
 }

--- a/bamboo-storage/src/test/java/com/pushtorefresh/android/bamboostorage/unit_test/design/GetOperationDesignTest.java
+++ b/bamboo-storage/src/test/java/com/pushtorefresh/android/bamboostorage/unit_test/design/GetOperationDesignTest.java
@@ -12,10 +12,10 @@ import rx.Observable;
 
 public class GetOperationDesignTest extends OperationDesignTest {
 
-    @Test public void getAsCursor() {
+    @Test public void getCursorBlocking() {
         Cursor cursor = bambooStorage()
                 .get()
-                .asCursor()
+                .cursor()
                 .query(new QueryBuilder()
                         .table("users")
                         .where("email = ?")
@@ -25,10 +25,10 @@ public class GetOperationDesignTest extends OperationDesignTest {
                 .executeAsBlocking();
     }
 
-    @Test public void getAsObjects() {
+    @Test public void getListOfObjectsBlocking() {
         List<User> users = bambooStorage()
                 .get()
-                .asListOfObjects(User.class)
+                .listOfObjects(User.class)
                 .mapFunc(User.MAP_FROM_CURSOR)
                 .query(new QueryBuilder()
                         .table("users")
@@ -39,10 +39,10 @@ public class GetOperationDesignTest extends OperationDesignTest {
                 .executeAsBlocking();
     }
 
-    @Test public void getAsObservableCursor() {
+    @Test public void getCursorObservable() {
         Observable<Cursor> observableCursor = bambooStorage()
                 .get()
-                .asCursor()
+                .cursor()
                 .query(new QueryBuilder()
                         .table("users")
                         .whereArgs("email = ?")
@@ -52,10 +52,10 @@ public class GetOperationDesignTest extends OperationDesignTest {
                 .createObservable();
     }
 
-    @Test public void getAsObservableObjects() {
+    @Test public void getListOfObjectsObservable() {
         Observable<List<User>> observableUsers = bambooStorage()
                 .get()
-                .asListOfObjects(User.class)
+                .listOfObjects(User.class)
                 .mapFunc(User.MAP_FROM_CURSOR)
                 .query(new QueryBuilder()
                         .table("users")


### PR DESCRIPTION
...> get().listOfObjects(), closes #44 

I'll merge it myself after CI