### PR TITLE
Added put().objects(T... objects) and put().objects(Iterable<T> objects)...

### DIFF
--- a/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/put/PreparedPut.java
+++ b/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/put/PreparedPut.java
@@ -6,7 +6,7 @@ import android.support.annotation.NonNull;
 import com.pushtorefresh.android.bamboostorage.BambooStorage;
 import com.pushtorefresh.android.bamboostorage.operation.PreparedOperation;
 
-import java.util.Collection;
+import java.util.Arrays;
 
 public abstract class PreparedPut<T, Result> implements PreparedOperation<Result> {
 
@@ -42,8 +42,12 @@ public abstract class PreparedPut<T, Result> implements PreparedOperation<Result
             return new PreparedPutWithObject.Builder<>(bambooStorage, object);
         }
 
-        @NonNull public <T> PreparedPutCollectionOfObjects.Builder<T> objects(@NonNull Collection<T> objects) {
-            return new PreparedPutCollectionOfObjects.Builder<>(bambooStorage, objects);
+        @NonNull public <T> PreparedPutObjects.Builder<T> objects(@NonNull Iterable<T> objects) {
+            return new PreparedPutObjects.Builder<>(bambooStorage, objects);
+        }
+
+        @NonNull public <T> PreparedPutObjects.Builder<T> objects(@NonNull T... objects) {
+            return new PreparedPutObjects.Builder<>(bambooStorage, Arrays.asList(objects));
         }
     }
 }

--- a/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/put/PreparedPutObjects.java
+++ b/bamboo-storage/src/main/java/com/pushtorefresh/android/bamboostorage/operation/put/PreparedPutObjects.java
@@ -6,22 +6,21 @@ import android.support.annotation.NonNull;
 import com.pushtorefresh.android.bamboostorage.BambooStorage;
 import com.pushtorefresh.android.bamboostorage.operation.MapFunc;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 import rx.Observable;
 import rx.Subscriber;
 
-public class PreparedPutCollectionOfObjects<T> extends PreparedPut<T, PutCollectionResult<T>> {
+public class PreparedPutObjects<T> extends PreparedPut<T, PutCollectionResult<T>> {
 
-    @NonNull private final Collection<T> objects;
+    @NonNull private final Iterable<T> objects;
     @NonNull private final MapFunc<T, ContentValues> mapFunc;
 
 
-    public PreparedPutCollectionOfObjects(@NonNull BambooStorage bambooStorage,
-                                          @NonNull PutResolver<T> putResolver,
-                                          @NonNull Collection<T> objects, @NonNull MapFunc<T, ContentValues> mapFunc) {
+    public PreparedPutObjects(@NonNull BambooStorage bambooStorage,
+                              @NonNull PutResolver<T> putResolver,
+                              @NonNull Iterable<T> objects, @NonNull MapFunc<T, ContentValues> mapFunc) {
         super(bambooStorage, putResolver);
         this.objects = objects;
         this.mapFunc = mapFunc;
@@ -56,12 +55,12 @@ public class PreparedPutCollectionOfObjects<T> extends PreparedPut<T, PutCollect
     public static class Builder<T> {
 
         @NonNull private final BambooStorage bambooStorage;
-        @NonNull private final Collection<T> objects;
+        @NonNull private final Iterable<T> objects;
 
         private MapFunc<T, ContentValues> mapFunc;
         private PutResolver<T> putResolver;
 
-        public Builder(@NonNull BambooStorage bambooStorage, @NonNull Collection<T> objects) {
+        public Builder(@NonNull BambooStorage bambooStorage, @NonNull Iterable<T> objects) {
             this.bambooStorage = bambooStorage;
             this.objects = objects;
         }
@@ -76,8 +75,8 @@ public class PreparedPutCollectionOfObjects<T> extends PreparedPut<T, PutCollect
             return this;
         }
 
-        @NonNull public PreparedPutCollectionOfObjects<T> prepare() {
-            return new PreparedPutCollectionOfObjects<>(
+        @NonNull public PreparedPutObjects<T> prepare() {
+            return new PreparedPutObjects<>(
                     bambooStorage,
                     putResolver,
                     objects,

--- a/bamboo-storage/src/test/java/com/pushtorefresh/android/bamboostorage/unit_test/design/PutOperationDesignTest.java
+++ b/bamboo-storage/src/test/java/com/pushtorefresh/android/bamboostorage/unit_test/design/PutOperationDesignTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import rx.Observable;
 
@@ -39,8 +38,8 @@ public class PutOperationDesignTest extends OperationDesignTest {
                 .createObservable();
     }
 
-    @Test public void putCollectionOfObjectsBlocking() {
-        List<User> users = new ArrayList<>();
+    @Test public void putObjectsIterableBlocking() {
+        Iterable<User> users = new ArrayList<>();
 
         PutCollectionResult<User> putResult = bambooStorage()
                 .put()
@@ -51,8 +50,32 @@ public class PutOperationDesignTest extends OperationDesignTest {
                 .executeAsBlocking();
     }
 
-    @Test public void putCollectionOfObjectsObservable() {
-        List<User> users = new ArrayList<>();
+    @Test public void putObjectsIterableObservable() {
+        Iterable<User> users = new ArrayList<>();
+
+        Observable<PutCollectionResult<User>> putResultObservable = bambooStorage()
+                .put()
+                .objects(users)
+                .withMapFunc(User.MAP_TO_CONTENT_VALUES)
+                .withPutResolver(User.PUT_RESOLVER)
+                .prepare()
+                .createObservable();
+    }
+
+    @Test public void putObjectsArrayBlocking() {
+        User[] users = new User[]{};
+
+        PutCollectionResult<User> putResult = bambooStorage()
+                .put()
+                .objects(users)
+                .withMapFunc(User.MAP_TO_CONTENT_VALUES)
+                .withPutResolver(User.PUT_RESOLVER)
+                .prepare()
+                .executeAsBlocking();
+    }
+
+    @Test public void putObjectsArrayObservable() {
+        User[] users = new User[]{};
 
         Observable<PutCollectionResult<User>> putResultObservable = bambooStorage()
                 .put()


### PR DESCRIPTION
..., closes #59

@nikitin-da PTAL

As you can see, I just reused `put().objects(Iterable<T> objects)` for array, I think it's better to do same thing for ContentValues, less code, less bugs :smile: #60